### PR TITLE
U/pferguso/reconfigure

### DIFF
--- a/descqa/configs/srv_analysistools.yaml
+++ b/descqa/configs/srv_analysistools.yaml
@@ -1,4 +1,4 @@
-subclass_name: srv_analysistools.TestMetric
+subclass_name: srv_analysistools.analysisToolsMetric
 description: 'test install of analysis tools'
 included_by_default: true
 
@@ -6,7 +6,7 @@ ra: 'ra'
 dec: 'dec'
 models: ['cModel']
 
-bands: ['r','i','g']
+bands: ['i']
 
 catalog_filters:
 

--- a/descqa/configs/srv_analysistools.yaml
+++ b/descqa/configs/srv_analysistools.yaml
@@ -6,7 +6,7 @@ ra: 'ra'
 dec: 'dec'
 models: ['cModel']
 
-bands: ['i']
+bands: ['g','r','i']
 
 catalog_filters:
 

--- a/descqa/reconfig_at.py
+++ b/descqa/reconfig_at.py
@@ -3,6 +3,8 @@ configuration routines for analysis tools
 """
 from __future__ import unicode_literals, division, print_function, absolute_import
 import numpy as np
+
+from lsst.analysis.tools.tasks.base import _StandinPlotInfo
 from lsst.analysis.tools.analysisPlots.analysisPlots import ( 
     WPerpPSFPlot, 
     ShapeSizeFractionalDiffScatterPlot,
@@ -14,34 +16,57 @@ from lsst.analysis.tools.analysisMetrics import (
     E1DiffMetric,
     E2DiffMetric,
 )
-
-__all__ = []
-
-
-def reconfigured_shapesize(band):
-    ''' Call analysis tools wperpPSFPlot and reconfigure for DP0.2'''
-    # call base class
-    shapesize = ShapeSizeFractionalMetric()
-    shapesize_plot = ShapeSizeFractionalDiffScatterPlot()
-    shapesize_plot.produce.addSummaryPlot = False
-    # config 
-    shapesize_plot.prep.selectors.snSelector.bands = band
-
-    #shapesize_plot.prep.bands=['r']
- 
-    # populate prep
-    shapesize.populatePrepFromProcess()
-    shapesize_plot.populatePrepFromProcess()
+from .plotting import plt
 
 
-    # get list of quantities
-    key_list_full = list(shapesize.prep.getInputSchema())
-    key_list = [key_list_full[i][0] for i in range(len(key_list_full))]
-    key_list_full2 = list(shapesize_plot.prep.getInputSchema())
-    key_list2 = [key_list_full2[i][0] for i in range(len(key_list_full2))]
-    key_list.extend(key_list2)
+__all__ = ["shapeSizeFractional"]
 
-    return shapesize, shapesize_plot, key_list
+class shapeSizeFractional():
+    return_types=["plot","metric"] # add metric names? 
+    band="r"
+    metric={}
+    plot={}
+    key_list=[]
+    def reconfigure(self,band="r"):
+        ''' Call analysis tools shapesize and reconfigure for DP0.2'''
+        self.band=band
+        # call base class
+        shapesize = ShapeSizeFractionalMetric()
+        shapesize_plot = ShapeSizeFractionalDiffScatterPlot()
+        shapesize_plot.produce.addSummaryPlot = False
+        # config 
+        shapesize_plot.prep.selectors.snSelector.bands = self.band
+
+        #shapesize_plot.prep.bands=['r']
+    
+        # populate prep
+        shapesize.populatePrepFromProcess()
+        shapesize_plot.populatePrepFromProcess()
+
+        # get list of quantities
+        key_list_full = list(shapesize.prep.getInputSchema())
+        key_list = [key_list_full[i][0] for i in range(len(key_list_full))]
+        key_list_full2 = list(shapesize_plot.prep.getInputSchema())
+        key_list2 = [key_list_full2[i][0] for i in range(len(key_list_full2))]
+        key_list.extend(key_list2)
+
+        self.metric=shapesize
+        self.plot=shapesize_plot
+        self.key_list=key_list
+
+    def run(self,data,output_dir,metric=True, plot=True):
+        if metric:
+            self.metric_values = self.metric(data,band=self.band)
+            for key in self.metric_values.keys():
+                print(self.metric_values[key])
+        if plot: 
+            stage1 = self.plot.prep(data,band=self.band)
+            stage2 = self.plot.process(data,band=self.band)
+            plot = self.plot.produce(stage2, plotInfo=_StandinPlotInfo(), band=self.band,skymap='DC2')
+            plt.savefig(output_dir+"shapesizeTest.png")
+            plt.close()
+      
+
 
 def reconfigured_E1Diff(band):
     ''' Call analysis tools wperpPSFPlot and reconfigure for DP0.2'''

--- a/descqa/reconfig_at.py
+++ b/descqa/reconfig_at.py
@@ -29,7 +29,8 @@ __all__ = [
     ]
 
 class analysisToolsReconfigure():
-    return_types=["plot","metric"] # add metric names? 
+    # base class to run analysisTools tests in the DESCQA framework
+    return_types=["plot","metric"] # in future could use this to only try to run plot/metric if they exist
     band="default"
     metric={}
     plot={}
@@ -37,6 +38,10 @@ class analysisToolsReconfigure():
     plot_name="defaultName.png"
 
     def get_keys(self):
+        """this task takes the tests after they have been configured and 
+        populatePrepFromProcess() has been run and gets a list of columns needed 
+        that is used for input to the generic-catalog-reader
+        """
         key_list_metric = list(self.metric.prep.getInputSchema())
         key_list = [key_list_metric[i][0] for i in range(len(key_list_metric))]
         key_list_plot = list(self.plot.prep.getInputSchema())

--- a/descqa/reconfig_at.py
+++ b/descqa/reconfig_at.py
@@ -3,6 +3,92 @@ configuration routines for analysis tools
 """
 from __future__ import unicode_literals, division, print_function, absolute_import
 import numpy as np
-
+from lsst.analysis.tools.analysisPlots.analysisPlots import ( 
+    WPerpPSFPlot, 
+    ShapeSizeFractionalDiffScatterPlot,
+    E1DiffScatterPlot,
+    E2DiffScatterPlot,
+)
+from lsst.analysis.tools.analysisMetrics import ( 
+    ShapeSizeFractionalMetric,
+    E1DiffMetric,
+    E2DiffMetric,
+)
 
 __all__ = []
+
+
+def reconfigured_shapesize(band):
+    ''' Call analysis tools wperpPSFPlot and reconfigure for DP0.2'''
+    # call base class
+    shapesize = ShapeSizeFractionalMetric()
+    shapesize_plot = ShapeSizeFractionalDiffScatterPlot()
+    shapesize_plot.produce.addSummaryPlot = False
+    # config 
+    shapesize_plot.prep.selectors.snSelector.bands = band
+
+    #shapesize_plot.prep.bands=['r']
+ 
+    # populate prep
+    shapesize.populatePrepFromProcess()
+    shapesize_plot.populatePrepFromProcess()
+
+
+    # get list of quantities
+    key_list_full = list(shapesize.prep.getInputSchema())
+    key_list = [key_list_full[i][0] for i in range(len(key_list_full))]
+    key_list_full2 = list(shapesize_plot.prep.getInputSchema())
+    key_list2 = [key_list_full2[i][0] for i in range(len(key_list_full2))]
+    key_list.extend(key_list2)
+
+    return shapesize, shapesize_plot, key_list
+
+def reconfigured_E1Diff(band):
+    ''' Call analysis tools wperpPSFPlot and reconfigure for DP0.2'''
+    # call base class
+    e1diff = E1DiffMetric()
+    e1diff_plot = E1DiffScatterPlot()
+    e1diff_plot.produce.addSummaryPlot = False
+    # config 
+    e1diff_plot.prep.selectors.snSelector.bands = band
+
+    #shapesize_plot.prep.bands=['r']
+ 
+    # populate prep
+    e1diff.populatePrepFromProcess()
+    e1diff_plot.populatePrepFromProcess()
+
+
+    # get list of quantities
+    key_list_full = list(e1diff.prep.getInputSchema())
+    key_list = [key_list_full[i][0] for i in range(len(key_list_full))]
+    key_list_full2 = list(e1diff_plot.prep.getInputSchema())
+    key_list2 = [key_list_full2[i][0] for i in range(len(key_list_full2))]
+    key_list.extend(key_list2)
+
+    return e1diff, e1diff_plot, key_list
+
+def reconfigured_E2Diff(band):
+    ''' Call analysis tools wperpPSFPlot and reconfigure for DP0.2'''
+    # call base class
+    e2diff = E2DiffMetric()
+    e2diff_plot = E2DiffScatterPlot()
+    e2diff_plot.produce.addSummaryPlot = False
+    # config 
+    e2diff_plot.prep.selectors.snSelector.bands = band
+
+    #shapesize_plot.prep.bands=['r']
+ 
+    # populate prep
+    e2diff.populatePrepFromProcess()
+    e2diff_plot.populatePrepFromProcess()
+
+
+    # get list of quantities
+    key_list_full = list(e2diff.prep.getInputSchema())
+    key_list = [key_list_full[i][0] for i in range(len(key_list_full))]
+    key_list_full2 = list(e2diff_plot.prep.getInputSchema())
+    key_list2 = [key_list_full2[i][0] for i in range(len(key_list_full2))]
+    key_list.extend(key_list2)
+
+    return e2diff, e2diff_plot, key_list

--- a/descqa/srv_analysistools.py
+++ b/descqa/srv_analysistools.py
@@ -14,7 +14,7 @@ from .base import BaseValidationTest, TestResult
 from .plotting import plt
 from .parallel import send_to_master
 
-from .reconfig_at import shapeSizeFractional
+from .reconfig_at import *
 comm = MPI.COMM_WORLD
 size = comm.Get_size()
 rank = comm.Get_rank()
@@ -173,7 +173,7 @@ class analysisToolsMetric(BaseValidationTest):
 
         # note: add quantity list and analysis tools version to output for reproducibility 
         if rank==0:
-            test=shapeSizeFractional()
+            test=WPerpPSF()
             test.reconfigure(band=self.bands[0])
             self.test = test
 
@@ -218,13 +218,15 @@ class analysisToolsMetric(BaseValidationTest):
         if rank==0:
 
             # call validation test run method
-            test.run(recvbuf,output_dir, metric=True, plot=True)
-            for key in test.metric_values.keys():
-                print(test.metric_values[key])
+            run_metric=False
+            run_plot=True
+            test.run(recvbuf,output_dir, metric=run_metric, plot=run_plot)
+            if run_metric:
+                for key in test.metric_values.keys():
+                    print(test.metric_values[key])
 
-
-            for key in test.metric_values.keys():
-                self.record_result({key: [test.metric_values[key], 'pass']},key)
+                for key in test.metric_values.keys():
+                    self.record_result({key: [test.metric_values[key], 'pass']},key)
                 
 
         if rank==0:

--- a/descqa/srv_analysistools.py
+++ b/descqa/srv_analysistools.py
@@ -14,53 +14,19 @@ from .base import BaseValidationTest, TestResult
 from .plotting import plt
 from .parallel import send_to_master
 
-#import lsst
-#import lsst.analysis
-import lsst.analysis.tools
-
-from lsst.analysis.tools.actions.scalar import MedianAction
-from lsst.analysis.tools.actions.vector import SnSelector, MagColumnNanoJansky, MagDiff
-from lsst.analysis.tools.interfaces import AnalysisMetric
-from lsst.analysis.tools.analysisPlots.analysisPlots import WPerpPSFPlot
-from lsst.analysis.tools.tasks.base import _StandinPlotInfo
-
+from .reconfig_at import shapeSizeFractional
 comm = MPI.COMM_WORLD
 size = comm.Get_size()
 rank = comm.Get_rank()
 
 
-__all__ = ['TestMetric','DemoMetric']
-
-
-def reconfigured_wperp():
-    ''''''
-    # call base class
-    wPerpAction = WPerpPSFPlot()
-
-    # reconfigure
-    wPerpAction.process.buildActions.x = MagDiff()
-    wPerpAction.process.buildActions.x.col1 = "g_psfFlux"
-    wPerpAction.process.buildActions.x.col2 = "r_psfFlux"
-    wPerpAction.process.buildActions.x.returnMillimags=False
-    wPerpAction.process.buildActions.y = MagDiff()
-    wPerpAction.process.buildActions.y.col1 = "r_psfFlux"
-    wPerpAction.process.buildActions.y.col2 = "i_psfFlux"
-    wPerpAction.process.buildActions.y.returnMillimags=False
-    wPerpAction.prep.selectors.snSelector.threshold = 100
- 
-    # populate prep
-    wPerpAction.populatePrepFromProcess()
-
-    # get list of quantities
-    key_list_full = list(wPerpAction.prep.getInputSchema())
-    key_list = [key_list_full[i][0] for i in range(len(key_list_full))]
-
-    return wPerpAction, key_list
+__all__ = ['analysisToolsMetric']
 
 
 
 
-class TestMetric(BaseValidationTest):
+
+class analysisToolsMetric(BaseValidationTest):
     """
     Check flux values and magnitudes
     """
@@ -101,7 +67,7 @@ class TestMetric(BaseValidationTest):
         self._individual_header = list()
         self._individual_table = list()
 
-        super(TestMetric, self).__init__(**kwargs)
+        super(analysisToolsMetric, self).__init__(**kwargs)
 
     def record_result(self, results, quantity_name=None, more_info=None, failed=None, individual_only=False):
         if isinstance(results, dict):
@@ -207,11 +173,12 @@ class TestMetric(BaseValidationTest):
 
         # note: add quantity list and analysis tools version to output for reproducibility 
         if rank==0:
-            wPerpAction, key_list = reconfigured_wperp()
-            self.wPerpAction = wPerpAction
+            test=shapeSizeFractional()
+            test.reconfigure(band=self.bands[0])
+            self.test = test
 
             quantities_new = []
-            for key in key_list:
+            for key in self.test.key_list:
                 if '{band}' in key:
                     for band in self.bands:
                         quantities_new.append(key.format(band=band))
@@ -250,15 +217,15 @@ class TestMetric(BaseValidationTest):
 
         if rank==0:
 
-            #wPerpAction, key_list = reconfigured_wperp()
+            # call validation test run method
+            test.run(recvbuf,output_dir, metric=True, plot=True)
+            for key in test.metric_values.keys():
+                print(test.metric_values[key])
 
-            stage1 = self.wPerpAction.prep(recvbuf)
-            stage2 = self.wPerpAction.process(stage1)
 
-            plot = self.wPerpAction.produce(stage2, plotInfo=_StandinPlotInfo())
-
-            plt.savefig(output_dir+"stellarLocusTest.png")
-            plt.close()
+            for key in test.metric_values.keys():
+                self.record_result({key: [test.metric_values[key], 'pass']},key)
+                
 
         if rank==0:
             self.generate_summary(output_dir)


### PR DESCRIPTION
Ok I think I am done with this branch for now I have it setup to be able to run: 
`"shapeSizeFractional",
"E1Diff",
"E2Diff",
"WPerpPSF"`

In `reconfig_at.py` there is a base class `analysisToolsReconfigure` that handles all of the generic stuff (get_keys and the run method), then each test has a reconfigure method that does all the custom stuff. 

to try different tests just change the class you instantiate on line 176 of srv_analystools.py

example call from `descqa/descqa` if ` ./run_master_parallel.sh -c lsst_object -t srv_analysistools`

it is possible that the `descqa/descqa/config/srv_analysistools.yaml ` will need to be changed for each test (I could even see specifying which test to run here, or at least wether the run configs currently hardcoded on line 221 of srv_analysistools.py