### PR TITLE
srv_external test

### DIFF
--- a/descqa/configs/srv_external.yaml
+++ b/descqa/configs/srv_external.yaml
@@ -1,0 +1,6 @@
+subclass_name: srv_external.srv_external
+description: 'Placeholder for a test being executed through an external pipeline, for test framework logging purposes'
+is_pseudo: false
+
+#report_directory: '/global/homes/n/nsevilla/plots/'
+report_directory: '/global/cfs/cdirs/lsst/www/txpipe/runs/2.2i-dr6c-2020-08-06/'

--- a/descqa/srv_external.py
+++ b/descqa/srv_external.py
@@ -1,0 +1,33 @@
+from __future__ import unicode_literals, absolute_import, division
+import os
+import numpy as np
+from .base import BaseValidationTest, TestResult
+from .plotting import plt
+
+__all__ = ['srv_external']
+
+class srv_external(BaseValidationTest):
+    """
+    A class to hold external validation tests
+    """
+    def __init__(self, **kwargs):
+
+        # load test config options
+        self.kwargs = kwargs
+        self.report_directory = kwargs.get('report_directory', './')
+
+    def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
+        test_result = None
+        # copy plots and text files to output directory
+        try:
+            cmd = 'cp {}/*.txt {}/.'.format(self.report_directory,output_dir)
+            os.system(cmd)
+            cmd = 'cp {}/*.png {}/.'.format(self.report_directory,output_dir)
+            os.system(cmd)
+            test_result = True
+        except:
+            test_result = False
+        return TestResult(passed=test_result,score=0)
+
+    def conclude_test(self, output_dir):
+        return None

--- a/descqarun/master.py
+++ b/descqarun/master.py
@@ -357,9 +357,23 @@ class DescqaTask(object):
                 if self.logger:
                     self.logger.debug(msg)
 
+                #verify if we need to skip the test from config
+                skip_test = self.get_description('is_pseudo')['validation_is_pseudo'][validation]
+                if skip_test:
+                    msg = '{} is not scheduled to run'.format(validation)
+                    self.logger.debug(msg)
+                    #create some output in self.output_dir
+                    with open('{}/{}_results.txt'.format(output_dir_this,validation), 'w') as f:
+                        f.write('This test has been skipped.\n') # to be filled with some info from config
+                    continue
+
                 test_result = None
                 with CatchExceptionAndStdStream(logfile, self.logger, msg):
+                    msg = 'Writing results to {}'.format(output_dir_this)
+                    self.logger.debug(msg)
                     test_result = validation_instance.run_on_single_catalog(catalog_instance, catalog, output_dir_this)
+                    msg = 'Test result for {} is {}'.format(validation, test_result)
+                    self.logger.debug(msg)
 
                 if rank==0:
                     self.set_result(test_result or 'RUN_VALIDATION_TEST_ERROR', validation, catalog)
@@ -452,13 +466,16 @@ def main():
 
 
     global GCRCatalogs #pylint: disable=W0601
-    sys.path.insert(0,'/global/homes/p/plarsen/plarsen_git/gcr-catalogs')
+    #sys.path.insert(0,'/global/homes/p/plarsen/plarsen_git/gcr-catalogs')
+    sys.path.insert(0,'/global/u1/n/nsevilla/srv/gcr-catalogs')
     GCRCatalogs = importlib.import_module('GCRCatalogs')
 
     #PL: note added assert, should do this for GCR too
-    assert(GCRCatalogs.__path__==['/global/homes/p/plarsen/plarsen_git/gcr-catalogs/GCRCatalogs'])
+    #assert(GCRCatalogs.__path__==['/global/homes/p/plarsen/plarsen_git/gcr-catalogs/GCRCatalogs'])
+    assert(GCRCatalogs.__path__==['/global/u1/n/nsevilla/srv/gcr-catalogs/GCRCatalogs'])
     if hasattr(GCRCatalogs,'GCR'):
-        assert(GCRCatalogs.GCR.__path__==['/global/homes/p/plarsen/plarsen_git/generic-catalog-reader/GCR'])
+        #assert(GCRCatalogs.GCR.__path__==['/global/homes/p/plarsen/plarsen_git/generic-catalog-reader/GCR'])
+        assert(GCRCatalogs.GCR.__path__==['/global/u1/n/nsevilla/srv/generic-catalog-reader/GCR'])
 
 
     '''global GCRCatalogs #pylint: disable=W0601

--- a/descqarun/master.py
+++ b/descqarun/master.py
@@ -471,7 +471,7 @@ def main():
     GCRCatalogs = importlib.import_module('GCRCatalogs')
 
     #PL: noe added assert, should do this for GCR too
-    assert#(GCRCatalogs.__path__==['/global/homes/p/plarsen/plarsen_git/gcr-catalogs/GCRCatalogs'])
+    assert(GCRCatalogs.__path__==['/global/homes/p/plarsen/plarsen_git/gcr-catalogs/GCRCatalogs'])
     #assert(GCRCatalogs.__path__==['/global/u1/n/nsevilla/srv/gcr-catalogs/GCRCatalogs'])
     if hasattr(GCRCatalogs,'GCR'):
         assert(GCRCatalogs.GCR.__path__==['/global/homes/p/plarsen/plarsen_git/generic-catalog-reader/GCR'])

--- a/descqarun/master.py
+++ b/descqarun/master.py
@@ -466,16 +466,16 @@ def main():
 
 
     global GCRCatalogs #pylint: disable=W0601
-    #sys.path.insert(0,'/global/homes/p/plarsen/plarsen_git/gcr-catalogs')
-    sys.path.insert(0,'/global/u1/n/nsevilla/srv/gcr-catalogs')
+    sys.path.insert(0,'/global/homes/p/plarsen/plarsen_git/gcr-catalogs')
+    #sys.path.insert(0,'/global/u1/n/nsevilla/srv/gcr-catalogs')
     GCRCatalogs = importlib.import_module('GCRCatalogs')
 
-    #PL: note added assert, should do this for GCR too
-    #assert(GCRCatalogs.__path__==['/global/homes/p/plarsen/plarsen_git/gcr-catalogs/GCRCatalogs'])
-    assert(GCRCatalogs.__path__==['/global/u1/n/nsevilla/srv/gcr-catalogs/GCRCatalogs'])
+    #PL: noe added assert, should do this for GCR too
+    assert#(GCRCatalogs.__path__==['/global/homes/p/plarsen/plarsen_git/gcr-catalogs/GCRCatalogs'])
+    #assert(GCRCatalogs.__path__==['/global/u1/n/nsevilla/srv/gcr-catalogs/GCRCatalogs'])
     if hasattr(GCRCatalogs,'GCR'):
-        #assert(GCRCatalogs.GCR.__path__==['/global/homes/p/plarsen/plarsen_git/generic-catalog-reader/GCR'])
-        assert(GCRCatalogs.GCR.__path__==['/global/u1/n/nsevilla/srv/generic-catalog-reader/GCR'])
+        assert(GCRCatalogs.GCR.__path__==['/global/homes/p/plarsen/plarsen_git/generic-catalog-reader/GCR'])
+        #assert(GCRCatalogs.GCR.__path__==['/global/u1/n/nsevilla/srv/generic-catalog-reader/GCR'])
 
 
     '''global GCRCatalogs #pylint: disable=W0601


### PR DESCRIPTION
Adding new test that pulls from a specified NERSC directory plots and txt to show through descqaweb. 

Example in:

https://portal.nersc.gov/cfs/lsst/descqa/v2/?run=2022-12-21&test=srv_external
